### PR TITLE
Bootstrap zkML prover crate

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = ["guardian_zkml"]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"

--- a/prover/guardian_zkml/Cargo.toml
+++ b/prover/guardian_zkml/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "guardian_zkml"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sha2 = "0.10"

--- a/prover/guardian_zkml/src/lib.rs
+++ b/prover/guardian_zkml/src/lib.rs
@@ -1,0 +1,44 @@
+use sha2::{Digest, Sha256};
+
+#[repr(C)]
+pub struct Input {
+    pub data: *const u8,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Output {
+    pub len: usize,
+    pub hash: [u8; 32],
+}
+
+pub fn generate_proof_slice(data: &[u8]) -> Output {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let hash = hasher.finalize();
+    Output { len: data.len(), hash: hash.into() }
+}
+
+pub fn verify_proof(data: &[u8], output: &Output) -> bool {
+    let expected = generate_proof_slice(data);
+    expected.len == output.len && expected.hash == output.hash
+}
+
+#[no_mangle]
+pub extern "C" fn generate_proof(input_ptr: *const Input, output_ptr: *mut Output) -> i32 {
+    // SAFETY: caller must provide valid pointers
+    if input_ptr.is_null() || output_ptr.is_null() {
+        return -1;
+    }
+    let input = unsafe { &*input_ptr };
+    if input.data.is_null() {
+        return -1;
+    }
+    let data = unsafe { std::slice::from_raw_parts(input.data, input.len) };
+    let out = generate_proof_slice(data);
+    unsafe {
+        *output_ptr = out;
+    }
+    0
+}

--- a/prover/guardian_zkml/tests/prover.rs
+++ b/prover/guardian_zkml/tests/prover.rs
@@ -1,0 +1,29 @@
+use guardian_zkml::{generate_proof_slice, verify_proof, Output, Input, generate_proof};
+use sha2::{Sha256, Digest};
+
+#[test]
+fn test_proof_round_trip() {
+    let data = b"hello world";
+    let out = generate_proof_slice(data);
+    assert_eq!(out.len, data.len());
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let expected = hasher.finalize();
+    assert_eq!(out.hash.as_slice(), expected.as_slice());
+    assert!(verify_proof(data, &out));
+}
+
+#[test]
+fn test_generate_proof_ffi() {
+    let data = b"ffi test";
+    let input = Input { data: data.as_ptr(), len: data.len() };
+    let mut output = Output { len: 0, hash: [0u8; 32] };
+    let ret = unsafe { generate_proof(&input as *const Input, &mut output as *mut Output) };
+    assert_eq!(ret, 0);
+    assert_eq!(output.len, data.len());
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let expected = hasher.finalize();
+    assert_eq!(output.hash.as_slice(), expected.as_slice());
+    assert!(verify_proof(data, &output));
+}


### PR DESCRIPTION
## Summary
- add workspace for prover
- create `guardian_zkml` crate with SHA-256 proof scaffold
- expose C ABI `generate_proof`
- add integration tests for proof round-trip

## Self-review
- `cargo test --all --offline` runs without failures
- `cargo bench --all --offline` also runs
- rustfmt component was unavailable in the environment

Closes #1

/assign @guardian-reviewers